### PR TITLE
arithmeticからmathに移行

### DIFF
--- a/NPC_VOICEROIDs/effects.json
+++ b/NPC_VOICEROIDs/effects.json
@@ -84,10 +84,10 @@
       {
         "condition": "ALWAYS",
         "values": [
-            { "value": "STRENGTH", "add": { "arithmetic": [ { "u_val": "var", "var_name": "band_count", "type": "counter", "context": "var_adjust_band" }, "/", { "const": 100 } ] } },
-            { "value": "DEXTERITY", "add": { "arithmetic": [ { "u_val": "var", "var_name": "band_count", "type": "counter", "context": "var_adjust_band" }, "/", { "const": 100 } ] } },
-            { "value": "INTELLIGENCE", "add": { "arithmetic": [ { "u_val": "var", "var_name": "band_count", "type": "counter", "context": "var_adjust_band" }, "/", { "const": 100 } ] } },
-            { "value": "PERCEPTION", "add": { "arithmetic": [ { "u_val": "var", "var_name": "band_count", "type": "counter", "context": "var_adjust_band" }, "/", { "const": 100 } ] } }
+            { "value": "STRENGTH", "add": {"math": ["u_counter_var_adjust_band_band_count / 100"] } },
+            { "value": "DEXTERITY", "add": {"math": ["u_counter_var_adjust_band_band_count / 100"] } },
+            { "value": "INTELLIGENCE", "add": {"math": ["u_counter_var_adjust_band_band_count / 100"] } },
+            { "value": "PERCEPTION", "add": {"math": ["u_counter_var_adjust_band_band_count / 100"] } }
         ]
       }
     ]


### PR DESCRIPTION
多分これで動くと思います。

arithmeticで使っていた変数はmathでは次のように参照できます。

{ "u_val": "var", "var_name": "var_name", "type": "type", "context": "context" }
=> u_var_name_context_var_name

{ "npc_val": "var", "var_name": "var_name", "type": "type", "context": "context" }
=> n_var_name_context_var_name

新しくmathで変数を作ったり値を変動させたりするときはu_~~やn_~~でOKです
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/NPCs.md#variables