### PR TITLE
死亡からの復活時にメッセージを表示する

### DIFF
--- a/NPC_VOICEROIDs/TALKS&SETTINGS/EOCs.json
+++ b/NPC_VOICEROIDs/TALKS&SETTINGS/EOCs.json
@@ -38,7 +38,28 @@
       { "u_set_hp": 45, "only_increase": true, "target_part": "leg_r" },
       { "u_set_hp": 45, "only_increase": true, "target_part": "leg_l" },
       { "math": [ "u_counter_var_love_points_love_point", "-=", "50" ] },
-      { "u_message": "<u_name>は力を振り絞って立ち上がった！" }
+      { "u_cast_spell": { "id": "spell_lovers_guts_message" } }
     ]
+  },
+  {
+    "id": "spell_lovers_guts_message",
+    "type": "SPELL",
+    "name": "spell_lovers_guts_message",
+    "description": "メッセージを表示するためのダミースペル",
+    "valid_targets": [ "self", "hostile", "ally" ],
+    "max_level": 1,
+    "flags": [ "SILENT", "NO_EXPLOSION_SFX" ],
+    "base_casting_time": 0,
+    "shape": "blast",
+    "min_range": 1,
+    "min_aoe": 100,
+    "max_aoe": 100,
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_event_lovers_guts_message"
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_event_lovers_guts_message",
+    "effect": [ { "u_message": "<npc_name>は力を振り絞って立ち上がった！", "popup": true } ]
   }
 ]

--- a/NPC_VOICEROIDs/TALKS&SETTINGS/YUKARI/talk_band_yukari.json
+++ b/NPC_VOICEROIDs/TALKS&SETTINGS/YUKARI/talk_band_yukari.json
@@ -162,7 +162,6 @@
           { "u_assign_activity": "ACT_TALK_BAND1_EOC", "duration": "10 minutes" },
           { "npc_assign_activity": "ACT_TALK_BAND1_EOC", "duration": "10 minutes" },
           { "math": [ "n_counter_var_love_points_love_point", "+=", "rand(4) + 3" ] },
-          { "math": [ "n_counter_var_love_points_love_point", "=", "100" ] },
           {
             "u_message": "腰を下ろしてゆっくりと会話しました。\n好感度が少し上がりました。",
             "popup": true

--- a/NPC_VOICEROIDs/TALKS&SETTINGS/YUKARI/talk_band_yukari.json
+++ b/NPC_VOICEROIDs/TALKS&SETTINGS/YUKARI/talk_band_yukari.json
@@ -162,6 +162,7 @@
           { "u_assign_activity": "ACT_TALK_BAND1_EOC", "duration": "10 minutes" },
           { "npc_assign_activity": "ACT_TALK_BAND1_EOC", "duration": "10 minutes" },
           { "math": [ "n_counter_var_love_points_love_point", "+=", "rand(4) + 3" ] },
+          { "math": [ "n_counter_var_love_points_love_point", "=", "100" ] },
           {
             "u_message": "腰を下ろしてゆっくりと会話しました。\n好感度が少し上がりました。",
             "popup": true


### PR DESCRIPTION
`character_dies`イベントのEOC内では u = 死亡した人、 npc = なしと設定されます。
死亡したのがプレイヤーでない場合、u_messageをしてもプレイヤーには通知されないためメッセージは表示されません

こういう場合に別のEOCを発動させプレイヤーをuまたはnpcに持ってくる方法はいくつかありますが、一番わかりやすいのはu_cast_spellでダミー呪文を発動してプレイヤーにぶつけてEOCを発動させることです
呪文のEOCはu = 対象、npc = 発動した人になるので、プレイヤーが呪文の範囲にいればu_messageでメッセージを出すことができます